### PR TITLE
Reduce DTLS ciphers to a more sane set of ciphers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 *.swp
 out/
-build/patches/*.patch
+webrtc/

--- a/build/patches/dtls-cipher-suites.patch
+++ b/build/patches/dtls-cipher-suites.patch
@@ -1,0 +1,15 @@
+diff --git a/rtc_base/openssl_stream_adapter.cc b/rtc_base/openssl_stream_adapter.cc
+index 7f4b79a53a..930f4f3271 100644
+--- a/rtc_base/openssl_stream_adapter.cc
++++ b/rtc_base/openssl_stream_adapter.cc
+@@ -1032,7 +1032,9 @@ SSL_CTX* OpenSSLStreamAdapter::SetupSSLContext() {
+   // with SHA256 or SHA384 as the handshake hash.
+   // This matches the list of SSLClientSocketOpenSSL in Chromium.
+   SSL_CTX_set_cipher_list(
+-      ctx, "DEFAULT:!NULL:!aNULL:!SHA256:!SHA384:!aECDH:!AESGCM+AES256:!aPSK");
++      ctx, "ECDHE-ECDSA-CHACHA20-POLY1305:"
++           "ECDHE-ECDSA-AES256-GCM-SHA384:"
++           "ECDHE-ECDSA-AES128-GCM-SHA256:");
+ 
+   if (!srtp_ciphers_.empty()) {
+     if (SSL_CTX_set_tlsext_use_srtp(ctx, srtp_ciphers_.c_str())) {


### PR DESCRIPTION
As reported by Wireshark, previously:

TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256 (0xcca9)
TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256 (0xcca8)
TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256 (0xc02b)
TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 (0xc02f)
TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA (0xc009)
TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA (0xc013)
TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA (0xc00a)
TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA (0xc014)
TLS_RSA_WITH_AES_128_GCM_SHA256 (0x009c)
TLS_RSA_WITH_AES_128_CBC_SHA (0x002f)
TLS_RSA_WITH_AES_256_CBC_SHA (0x0035)
TLS_RSA_WITH_3DES_EDE_CBC_SHA (0x000a)

Now:

TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256 (0xcca9)
TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384 (0xc02c)
TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256 (0xc02b)
