### PR TITLE
Reduce/Reorder SRTP ciphers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 *.swp
 out/
-build/patches/*.patch
+webrtc/

--- a/build/patches/srtp-cipher-suites.patch
+++ b/build/patches/srtp-cipher-suites.patch
@@ -1,0 +1,17 @@
+diff --git a/rtc_base/openssl_stream_adapter.cc b/rtc_base/openssl_stream_adapter.cc
+index 7f4b79a53a..1dc5d21241 100644
+--- a/rtc_base/openssl_stream_adapter.cc
++++ b/rtc_base/openssl_stream_adapter.cc
+@@ -67,10 +67,9 @@ struct SslCipherMapEntry {
+ 
+ // This isn't elegant, but it's better than an external reference
+ constexpr SrtpCipherMapEntry kSrtpCipherMap[] = {
+-    {"SRTP_AES128_CM_SHA1_80", SRTP_AES128_CM_SHA1_80},
+-    {"SRTP_AES128_CM_SHA1_32", SRTP_AES128_CM_SHA1_32},
++    {"SRTP_AEAD_AES_256_GCM", SRTP_AEAD_AES_256_GCM},
+     {"SRTP_AEAD_AES_128_GCM", SRTP_AEAD_AES_128_GCM},
+-    {"SRTP_AEAD_AES_256_GCM", SRTP_AEAD_AES_256_GCM}};
++    {"SRTP_AES128_CM_SHA1_80", SRTP_AES128_CM_SHA1_80}};
+ 
+ #ifndef OPENSSL_IS_BORINGSSL
+ // The "SSL_CIPHER_standard_name" function is only available in OpenSSL when


### PR DESCRIPTION
Bans the (arguably weak) AES 128 CM SHA1 32 cipher.

Moves the AES 128 CM SHA1 80 cipher down (can still be disabled via
peer connection settings).

Tested to be reflected in a Wireshark trace.