### PR TITLE
Fix two-byte RTP header extension encryption

### DIFF
--- a/build/patches/libsrtp-two-byte-rtp-header-extension-crypto.patch
+++ b/build/patches/libsrtp-two-byte-rtp-header-extension-crypto.patch
@@ -1,0 +1,13 @@
+diff --git a//third_party/libsrtp/srtp/srtp.c b//third_party/libsrtp/srtp/srtp.c
+index 4462501..bfb596e 100644
+--- a//third_party/libsrtp/srtp/srtp.c
++++ b//third_party/libsrtp/srtp/srtp.c
+@@ -1422,7 +1422,7 @@ static srtp_err_status_t srtp_process_header_encryption(
+                 xtn_hdr_data++;
+             }
+         }
+-    } else if ((ntohs(xtn_hdr->profile_specific) & 0x1fff) == 0x100) {
++    } else if ((ntohs(xtn_hdr->profile_specific) & 0xfff0) == 0x1000) {
+         /* RFC 5285, section 4.3. Two-Byte Header */
+         while (xtn_hdr_data + 1 < xtn_hdr_end) {
+             uint8_t xid = *xtn_hdr_data;


### PR DESCRIPTION
See: https://github.com/cisco/libsrtp/pull/491