### PR TITLE
Add build-final.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ the resulting build into your application.**
 
 ## TL;DR
 
-For an initial build:
+For an initial local build:
 
     ./cli.sh build-tools
     ./cli.sh fetch
@@ -23,7 +23,12 @@ For subsequent builds after an update:
     ./cli.sh patch
     ./cli.sh build-all
 
-## Usage
+For a (somewhat) reproducible build, created from within a temporary Docker container:
+
+    ./cli.sh build-tools
+    ./build-final.sh <revision>
+
+## Usage: cli.sh
 
 First, build the tools image:
 
@@ -84,6 +89,22 @@ tools need updating or that the code needs to be fetched again. To clean and
 start from scratch, run:
 
     ./cli.sh clean
+
+## Usage: build-final.sh
+
+To generate a (somewhat) reproducible build, without any caching and with the
+whole process being done from within a temporary, deterministic Docker
+container:
+
+    ./cli.sh build-tools
+    ./build-final.sh <revision>
+
+This guarantees the absence of a cache (because it always fetches fresh code),
+consistent permissions and filesystem paths (so that your username and workdir
+isn't included in the binary's debug info) and will ensure that you don't
+forget to apply patches (because it always applies all patches at
+`patches/*.patch`).
+
 
 ## Patches
 

--- a/build-final.sh
+++ b/build-final.sh
@@ -18,7 +18,6 @@ docker run --rm -ti -v "$(pwd)/out:/out" -v "$(pwd)/patches:/patches" \
     set -euo pipefail
     shopt -s nullglob
 
-    export GYP_DEFINES='OS=android'
     export WEBRTC_COMPILE_ARGS='$BUILD_ARGS'
     export OUT='/out'
 
@@ -35,7 +34,6 @@ docker run --rm -ti -v "$(pwd)/out:/out" -v "$(pwd)/patches:/patches" \
     echo '==> Log revision and build args'
     git log --pretty=fuller HEAD...HEAD^ > \$OUT/revision.txt
     echo \"WEBRTC_COMPILE_ARGS: \$WEBRTC_COMPILE_ARGS\" >> \$OUT/build_args.txt
-    echo \"GYP_DEFINES: \$GYP_DEFINES\" >> \$OUT/build_args.txt
 
     echo '==> Apply patches'
     for p in /patches/*.patch; do echo \"Applying \$p...\"; git apply \$p; done 

--- a/build-final.sh
+++ b/build-final.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+set -euo pipefail
+
+IMAGE=threema/webrtc-build-tools:latest
+TARGETS="${WEBRTC_TARGETS:-arm arm64 x86 x64}"
+BUILD_ARGS="${WEBRTC_BUILD_ARGS:-symbol_level=1 enable_libaom=false}"
+
+if [ $# -ne 1 ]; then
+    echo "Usage: $0 <revision>"
+    echo "Example: $0 branch-heads/4430"
+    exit 1
+fi
+revision=$1
+
+mkdir -p out && chmod 777 out
+docker run --rm -ti -v "$(pwd)/out:/out" -v "$(pwd)/patches:/patches" \
+    $IMAGE /bin/bash -c "
+    set -euo pipefail
+    shopt -s nullglob
+
+    export GYP_DEFINES='OS=android'
+    export WEBRTC_COMPILE_ARGS='$BUILD_ARGS'
+    export OUT='/out'
+
+    echo '==> Fetching sources'
+    fetch webrtc_android
+    cd src
+
+    echo '==> Checking out revision $revision'
+    git checkout $revision
+
+    echo '==> Run gclient sync'
+    gclient sync
+
+    echo '==> Log revision and build args'
+    git log --pretty=fuller HEAD...HEAD^ > \$OUT/revision.txt
+    echo \"WEBRTC_COMPILE_ARGS: \$WEBRTC_COMPILE_ARGS\" >> \$OUT/build_args.txt
+    echo \"GYP_DEFINES: \$GYP_DEFINES\" >> \$OUT/build_args.txt
+
+    echo '==> Apply patches'
+    for p in /patches/*.patch; do echo \"Applying \$p...\"; git apply \$p; done 
+    ls -noa --time-style=long-iso /patches/*.patch > \$OUT/patches.txt
+
+    echo '==> Build'
+    for target in $TARGETS; do
+        echo \"--> Building \$target\"
+
+        gn gen out/\$target --args=\"is_debug=false target_os=\\\"android\\\" target_cpu=\\\"\$target\\\" \$WEBRTC_COMPILE_ARGS\"
+        bash -c \"source build/android/envsetup.sh && autoninja -C out/\$target webrtc\"
+
+        mkdir -p \$OUT/\$target/
+        cp out/arm/libjingle_peerconnection_so.so \$OUT/\$target/
+    done
+    cp out/arm64/lib.java/sdk/android/libwebrtc.jar \$OUT/
+
+    echo 'Done!'
+"

--- a/build-final.sh
+++ b/build-final.sh
@@ -49,7 +49,7 @@ docker run --rm -ti -v "$(pwd)/out:/out" -v "$(pwd)/patches:/patches" \
         bash -c \"source build/android/envsetup.sh && autoninja -C out/\$target webrtc\"
 
         mkdir -p \$OUT/\$target/
-        cp out/arm/libjingle_peerconnection_so.so \$OUT/\$target/
+        cp out/\$target/libjingle_peerconnection_so.so \$OUT/\$target/
     done
     cp out/arm64/lib.java/sdk/android/libwebrtc.jar \$OUT/
 


### PR DESCRIPTION
This is meant to replace the old two-step build process with a bash script based on the `build-tools` image.

It guarantees the absence of a cache (because it always fetches fresh code), consistent permissions and filesystem paths (so that your username isn't included in the binary's debug info) and will ensure that you don't forget to apply patches.

The `cli.sh` approach is better for local development of patches, but the new script is better for final builds.