### PR TITLE
Update patches for M110

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.swp
+.vscode/
 out/
 out-*/
 webrtc/

--- a/build-final.sh
+++ b/build-final.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 IMAGE=threema/webrtc-build-tools:latest
 TARGETS="${WEBRTC_TARGETS:-arm arm64 x86 x64}"
-BUILD_ARGS="${WEBRTC_BUILD_ARGS:-symbol_level=1 enable_libaom=false}"
+BUILD_ARGS="${WEBRTC_BUILD_ARGS:-symbol_level=1 enable_libaom=false rtc_include_dav1d_in_internal_decoder_factory=false rtc_include_ilbc=false}"
 
 if [ $# -ne 1 ]; then
     echo "Usage: $0 <revision>"

--- a/cli.sh
+++ b/cli.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 TARGETS="${WEBRTC_TARGETS:-arm arm64 x86 x64}"
-BUILD_ARGS="${WEBRTC_BUILD_ARGS:-symbol_level=1 enable_libaom=false}"
+BUILD_ARGS="${WEBRTC_BUILD_ARGS:-symbol_level=1 enable_libaom=false rtc_include_dav1d_in_internal_decoder_factory=false rtc_include_ilbc=false}"
 
 function print_usage {
     echo "Usage: $0 <command> [<args>]"

--- a/cli.sh
+++ b/cli.sh
@@ -95,7 +95,7 @@ case ${1-} in
             echo 'Checking out revision $revision'
             cd src && git checkout $revision && cd -
             echo 'Updating third party repos and running pre-compile hooks'
-            gclient sync
+            gclient sync -D
         "
         ;;
     
@@ -116,7 +116,7 @@ case ${1-} in
             echo \"Updating current branch (\$(cd src && git branch --show-current))\"
             (cd src && git rebase-update --current)
             echo 'Updating third party repos and running pre-compile hooks'
-            gclient sync
+            gclient sync -D
             echo 'Done. Any patches and uncommited changes to libwebrtc need to be reapplied.'
         "
         ;;

--- a/patches/disable-dtmf-and-comfort-noise.patch
+++ b/patches/disable-dtmf-and-comfort-noise.patch
@@ -1,5 +1,5 @@
 diff --git a/media/engine/webrtc_voice_engine.cc b/media/engine/webrtc_voice_engine.cc
-index e090fcf62f..7b3d904d6e 100644
+index b6296a1993..3db9d6a7cf 100644
 --- a/media/engine/webrtc_voice_engine.cc
 +++ b/media/engine/webrtc_voice_engine.cc
 @@ -647,13 +647,6 @@ std::vector<AudioCodec> WebRtcVoiceEngine::CollectCodecs(
@@ -59,7 +59,7 @@ index e090fcf62f..7b3d904d6e 100644
    return out;
  }
  
-@@ -1632,20 +1596,6 @@ bool WebRtcVoiceMediaChannel::SetSendCodecs(
+@@ -1631,20 +1595,6 @@ bool WebRtcVoiceMediaChannel::SetSendCodecs(
      }
    }
  
@@ -80,7 +80,7 @@ index e090fcf62f..7b3d904d6e 100644
    // Scan through the list to figure out the codec to use for sending.
    absl::optional<webrtc::AudioSendStream::Config::SendCodecSpec>
        send_codec_spec;
-@@ -1684,36 +1634,6 @@ bool WebRtcVoiceMediaChannel::SetSendCodecs(
+@@ -1683,36 +1633,6 @@ bool WebRtcVoiceMediaChannel::SetSendCodecs(
    }
  
    RTC_DCHECK(voice_codec_info);
@@ -118,15 +118,19 @@ index e090fcf62f..7b3d904d6e 100644
    // Loop through the codecs to find the RED codec that matches opus
    // with respect to clockrate and number of channels.
 diff --git a/sdk/android/api/org/webrtc/RtpSender.java b/sdk/android/api/org/webrtc/RtpSender.java
-index b78bbf6b3c..e16731e207 100644
+index 2d0bc6c1e1..377ec15970 100644
 --- a/sdk/android/api/org/webrtc/RtpSender.java
 +++ b/sdk/android/api/org/webrtc/RtpSender.java
-@@ -27,8 +27,7 @@ public class RtpSender {
+@@ -28,12 +28,7 @@ public class RtpSender {
      long nativeTrack = nativeGetTrack(nativeRtpSender);
      cachedTrack = MediaStreamTrack.createMediaStreamTrack(nativeTrack);
  
--    long nativeDtmfSender = nativeGetDtmfSender(nativeRtpSender);
--    dtmfSender = (nativeDtmfSender != 0) ? new DtmfSender(nativeDtmfSender) : null;
+-    if (nativeGetMediaType(nativeRtpSender).equalsIgnoreCase(MediaStreamTrack.AUDIO_TRACK_KIND)) {
+-      long nativeDtmfSender = nativeGetDtmfSender(nativeRtpSender);
+-      dtmfSender = (nativeDtmfSender != 0) ? new DtmfSender(nativeDtmfSender) : null;
+-    } else {
+-      dtmfSender = null;
+-    }
 +    dtmfSender = null;
    }
  

--- a/patches/disable-unused-audio-codecs.patch
+++ b/patches/disable-unused-audio-codecs.patch
@@ -55,10 +55,10 @@ index 20259b9ad8..bda92b1a20 100644
  
  }  // namespace webrtc
 diff --git a/api/audio_codecs/builtin_audio_decoder_factory.cc b/api/audio_codecs/builtin_audio_decoder_factory.cc
-index 963cfe5cb9..db29a840a8 100644
+index 881113d985..db29a840a8 100644
 --- a/api/audio_codecs/builtin_audio_decoder_factory.cc
 +++ b/api/audio_codecs/builtin_audio_decoder_factory.cc
-@@ -13,18 +13,9 @@
+@@ -13,17 +13,9 @@
  #include <memory>
  #include <vector>
  
@@ -69,7 +69,6 @@ index 963cfe5cb9..db29a840a8 100644
 -#if WEBRTC_USE_BUILTIN_ILBC
 -#include "api/audio_codecs/ilbc/audio_decoder_ilbc.h"  // nogncheck
 -#endif
--#include "api/audio_codecs/isac/audio_decoder_isac.h"
 -#if WEBRTC_USE_BUILTIN_OPUS
  #include "api/audio_codecs/opus/audio_decoder_multi_channel_opus.h"
 -#include "api/audio_codecs/opus/audio_decoder_opus.h"  // nogncheck
@@ -78,7 +77,7 @@ index 963cfe5cb9..db29a840a8 100644
  
  namespace webrtc {
  
-@@ -52,18 +43,7 @@ struct NotAdvertised {
+@@ -51,18 +43,7 @@ struct NotAdvertised {
  
  rtc::scoped_refptr<AudioDecoderFactory> CreateBuiltinAudioDecoderFactory() {
    return CreateAudioDecoderFactory<
@@ -87,7 +86,7 @@ index 963cfe5cb9..db29a840a8 100644
 -      AudioDecoderOpus, NotAdvertised<AudioDecoderMultiChannelOpus>,
 -#endif
 -
--      AudioDecoderIsac, AudioDecoderG722,
+-      AudioDecoderG722,
 -
 -#if WEBRTC_USE_BUILTIN_ILBC
 -      AudioDecoderIlbc,
@@ -99,10 +98,10 @@ index 963cfe5cb9..db29a840a8 100644
  
  }  // namespace webrtc
 diff --git a/api/audio_codecs/builtin_audio_encoder_factory.cc b/api/audio_codecs/builtin_audio_encoder_factory.cc
-index 530d64b2ba..8f566fd62b 100644
+index 4546a2eaee..8f566fd62b 100644
 --- a/api/audio_codecs/builtin_audio_encoder_factory.cc
 +++ b/api/audio_codecs/builtin_audio_encoder_factory.cc
-@@ -13,18 +13,9 @@
+@@ -13,17 +13,9 @@
  #include <memory>
  #include <vector>
  
@@ -113,7 +112,6 @@ index 530d64b2ba..8f566fd62b 100644
 -#if WEBRTC_USE_BUILTIN_ILBC
 -#include "api/audio_codecs/ilbc/audio_encoder_ilbc.h"  // nogncheck
 -#endif
--#include "api/audio_codecs/isac/audio_encoder_isac.h"
 -#if WEBRTC_USE_BUILTIN_OPUS
  #include "api/audio_codecs/opus/audio_encoder_multi_channel_opus.h"
 -#include "api/audio_codecs/opus/audio_encoder_opus.h"  // nogncheck
@@ -122,7 +120,7 @@ index 530d64b2ba..8f566fd62b 100644
  
  namespace webrtc {
  
-@@ -58,18 +49,7 @@ struct NotAdvertised {
+@@ -57,18 +49,7 @@ struct NotAdvertised {
  
  rtc::scoped_refptr<AudioEncoderFactory> CreateBuiltinAudioEncoderFactory() {
    return CreateAudioEncoderFactory<
@@ -131,7 +129,7 @@ index 530d64b2ba..8f566fd62b 100644
 -      AudioEncoderOpus, NotAdvertised<AudioEncoderMultiChannelOpus>,
 -#endif
 -
--      AudioEncoderIsac, AudioEncoderG722,
+-      AudioEncoderG722,
 -
 -#if WEBRTC_USE_BUILTIN_ILBC
 -      AudioEncoderIlbc,
@@ -330,124 +328,6 @@ index b497948491..fce0527011 100644
 -    return nullptr;
 -  }
 -  return std::make_unique<AudioEncoderIlbcImpl>(config, payload_type);
-+  return nullptr; // disabled
- }
- 
- }  // namespace webrtc
-diff --git a/api/audio_codecs/isac/audio_decoder_isac_fix.cc b/api/audio_codecs/isac/audio_decoder_isac_fix.cc
-index b3ab91da47..77becc9ce9 100644
---- a/api/audio_codecs/isac/audio_decoder_isac_fix.cc
-+++ b/api/audio_codecs/isac/audio_decoder_isac_fix.cc
-@@ -28,16 +28,14 @@ absl::optional<AudioDecoderIsacFix::Config> AudioDecoderIsacFix::SdpToConfig(
- 
- void AudioDecoderIsacFix::AppendSupportedDecoders(
-     std::vector<AudioCodecSpec>* specs) {
--  specs->push_back({{"ISAC", 16000, 1}, {16000, 1, 32000, 10000, 32000}});
-+  // disabled
- }
- 
- std::unique_ptr<AudioDecoder> AudioDecoderIsacFix::MakeAudioDecoder(
-     Config config,
-     absl::optional<AudioCodecPairId> /*codec_pair_id*/,
-     const FieldTrialsView* field_trials) {
--  AudioDecoderIsacFixImpl::Config c;
--  c.sample_rate_hz = 16000;
--  return std::make_unique<AudioDecoderIsacFixImpl>(c);
-+  return nullptr; // disabled
- }
- 
- }  // namespace webrtc
-diff --git a/api/audio_codecs/isac/audio_decoder_isac_float.cc b/api/audio_codecs/isac/audio_decoder_isac_float.cc
-index 98f672b468..813819d569 100644
---- a/api/audio_codecs/isac/audio_decoder_isac_float.cc
-+++ b/api/audio_codecs/isac/audio_decoder_isac_float.cc
-@@ -36,21 +36,14 @@ AudioDecoderIsacFloat::SdpToConfig(const SdpAudioFormat& format) {
- 
- void AudioDecoderIsacFloat::AppendSupportedDecoders(
-     std::vector<AudioCodecSpec>* specs) {
--  specs->push_back({{"ISAC", 16000, 1}, {16000, 1, 32000, 10000, 32000}});
--  specs->push_back({{"ISAC", 32000, 1}, {32000, 1, 56000, 10000, 56000}});
-+  // disabled
- }
- 
- std::unique_ptr<AudioDecoder> AudioDecoderIsacFloat::MakeAudioDecoder(
-     Config config,
-     absl::optional<AudioCodecPairId> /*codec_pair_id*/,
-     const FieldTrialsView* field_trials) {
--  AudioDecoderIsacFloatImpl::Config c;
--  c.sample_rate_hz = config.sample_rate_hz;
--  if (!config.IsOk()) {
--    RTC_DCHECK_NOTREACHED();
--    return nullptr;
--  }
--  return std::make_unique<AudioDecoderIsacFloatImpl>(c);
-+  return nullptr; // disabled
- }
- 
- }  // namespace webrtc
-diff --git a/api/audio_codecs/isac/audio_encoder_isac_fix.cc b/api/audio_codecs/isac/audio_encoder_isac_fix.cc
-index 39603775a4..84ca29e033 100644
---- a/api/audio_codecs/isac/audio_encoder_isac_fix.cc
-+++ b/api/audio_codecs/isac/audio_encoder_isac_fix.cc
-@@ -42,9 +42,7 @@ absl::optional<AudioEncoderIsacFix::Config> AudioEncoderIsacFix::SdpToConfig(
- 
- void AudioEncoderIsacFix::AppendSupportedEncoders(
-     std::vector<AudioCodecSpec>* specs) {
--  const SdpAudioFormat fmt = {"ISAC", 16000, 1};
--  const AudioCodecInfo info = QueryAudioEncoder(*SdpToConfig(fmt));
--  specs->push_back({fmt, info});
-+  // disabled
- }
- 
- AudioCodecInfo AudioEncoderIsacFix::QueryAudioEncoder(
-@@ -58,15 +56,7 @@ std::unique_ptr<AudioEncoder> AudioEncoderIsacFix::MakeAudioEncoder(
-     int payload_type,
-     absl::optional<AudioCodecPairId> /*codec_pair_id*/,
-     const FieldTrialsView* field_trials) {
--  AudioEncoderIsacFixImpl::Config c;
--  c.frame_size_ms = config.frame_size_ms;
--  c.bit_rate = config.bit_rate;
--  c.payload_type = payload_type;
--  if (!config.IsOk()) {
--    RTC_DCHECK_NOTREACHED();
--    return nullptr;
--  }
--  return std::make_unique<AudioEncoderIsacFixImpl>(c);
-+  return nullptr; // disabled
- }
- 
- }  // namespace webrtc
-diff --git a/api/audio_codecs/isac/audio_encoder_isac_float.cc b/api/audio_codecs/isac/audio_encoder_isac_float.cc
-index e3e50080fa..5bcea0f1bd 100644
---- a/api/audio_codecs/isac/audio_encoder_isac_float.cc
-+++ b/api/audio_codecs/isac/audio_encoder_isac_float.cc
-@@ -49,11 +49,7 @@ AudioEncoderIsacFloat::SdpToConfig(const SdpAudioFormat& format) {
- 
- void AudioEncoderIsacFloat::AppendSupportedEncoders(
-     std::vector<AudioCodecSpec>* specs) {
--  for (int sample_rate_hz : {16000, 32000}) {
--    const SdpAudioFormat fmt = {"ISAC", sample_rate_hz, 1};
--    const AudioCodecInfo info = QueryAudioEncoder(*SdpToConfig(fmt));
--    specs->push_back({fmt, info});
--  }
-+  // disabled
- }
- 
- AudioCodecInfo AudioEncoderIsacFloat::QueryAudioEncoder(
-@@ -70,16 +66,7 @@ std::unique_ptr<AudioEncoder> AudioEncoderIsacFloat::MakeAudioEncoder(
-     int payload_type,
-     absl::optional<AudioCodecPairId> /*codec_pair_id*/,
-     const FieldTrialsView* field_trials) {
--  AudioEncoderIsacFloatImpl::Config c;
--  c.payload_type = payload_type;
--  c.sample_rate_hz = config.sample_rate_hz;
--  c.frame_size_ms = config.frame_size_ms;
--  c.bit_rate = config.bit_rate;
--  if (!config.IsOk()) {
--    RTC_DCHECK_NOTREACHED();
--    return nullptr;
--  }
--  return std::make_unique<AudioEncoderIsacFloatImpl>(c);
 +  return nullptr; // disabled
  }
  

--- a/patches/group-call-frame-crypto.patch
+++ b/patches/group-call-frame-crypto.patch
@@ -1,8 +1,8 @@
 diff --git a/pc/BUILD.gn b/pc/BUILD.gn
-index 26a044b615..933c4ce2e2 100644
+index 15c87dda25..1b2098e4dd 100644
 --- a/pc/BUILD.gn
 +++ b/pc/BUILD.gn
-@@ -1220,6 +1220,28 @@ rtc_source_set("peer_connection") {
+@@ -1224,6 +1224,28 @@ rtc_source_set("peer_connection") {
    ]
  }
  
@@ -1958,7 +1958,7 @@ index 0000000000..cd38b1ba00
 +}
 +#endif
 diff --git a/sdk/android/BUILD.gn b/sdk/android/BUILD.gn
-index b3f641a2f7..a4730fd281 100644
+index 8ef08a3a5b..4a6d8a08d6 100644
 --- a/sdk/android/BUILD.gn
 +++ b/sdk/android/BUILD.gn
 @@ -300,6 +300,7 @@ if (is_android) {
@@ -1969,7 +1969,7 @@ index b3f641a2f7..a4730fd281 100644
        "src/java/org/webrtc/NativeAndroidVideoTrackSource.java",
        "src/java/org/webrtc/NativeCapturerObserver.java",
        "src/java/org/webrtc/NativeLibrary.java",
-@@ -755,9 +756,12 @@ if (current_os == "linux" || is_android) {
+@@ -754,9 +755,12 @@ if (current_os == "linux" || is_android) {
        "src/jni/pc/stats_observer.h",
        "src/jni/pc/turn_customizer.cc",
        "src/jni/pc/turn_customizer.h",
@@ -1982,7 +1982,7 @@ index b3f641a2f7..a4730fd281 100644
        ":base_jni",
        ":generated_external_classes_jni",
        ":generated_peerconnection_jni",
-@@ -775,6 +779,7 @@ if (current_os == "linux" || is_android) {
+@@ -776,6 +780,7 @@ if (current_os == "linux" || is_android) {
        "../../api/rtc_event_log:rtc_event_log_factory",
        "../../api/task_queue:default_task_queue_factory",
        "../../api/video_codecs:video_codecs_api",
@@ -1990,7 +1990,7 @@ index b3f641a2f7..a4730fd281 100644
        "../../call:call_interfaces",
        "../../media:rtc_audio_video",
        "../../media:rtc_media_base",
-@@ -782,6 +787,7 @@ if (current_os == "linux" || is_android) {
+@@ -783,6 +788,7 @@ if (current_os == "linux" || is_android) {
        "../../modules/audio_processing:api",
        "../../modules/utility",
        "../../pc:media_stream_observer",
@@ -1998,7 +1998,7 @@ index b3f641a2f7..a4730fd281 100644
        "../../pc:webrtc_sdp",
        "../../rtc_base",
        "../../rtc_base:checks",
-@@ -1385,6 +1391,7 @@ if (current_os == "linux" || is_android) {
+@@ -1407,6 +1413,7 @@ if (current_os == "linux" || is_android) {
        "api/org/webrtc/StatsObserver.java",
        "api/org/webrtc/StatsReport.java",
        "api/org/webrtc/TurnCustomizer.java",
@@ -2006,23 +2006,6 @@ index b3f641a2f7..a4730fd281 100644
      ]
      namespace = "webrtc::jni"
      jni_generator_include = "//sdk/android/src/jni/jni_generator_helper.h"
-diff --git a/sdk/android/api/org/webrtc/RtpReceiver.java b/sdk/android/api/org/webrtc/RtpReceiver.java
-index a5710f92e3..dcec8860e3 100644
---- a/sdk/android/api/org/webrtc/RtpReceiver.java
-+++ b/sdk/android/api/org/webrtc/RtpReceiver.java
-@@ -61,6 +61,12 @@ public class RtpReceiver {
-     nativeRtpReceiver = 0;
-   }
- 
-+  /** Returns a pointer to webrtc::RtpSenderInterface. */
-+  long getNativeRtpReceiver() {
-+    checkRtpReceiverExists();
-+    return nativeRtpReceiver;
-+  }
-+
-   public void SetObserver(Observer observer) {
-     checkRtpReceiverExists();
-     // Unset the existing one before setting a new one.
 diff --git a/sdk/android/api/org/webrtc/ThreemaGroupCallFrameCryptoContext.java b/sdk/android/api/org/webrtc/ThreemaGroupCallFrameCryptoContext.java
 new file mode 100644
 index 0000000000..005cd5e81c


### PR DESCRIPTION
Apparently, AV1 decoding was accidentally enabled in our M108 builds.

The ISAC codec was removed which explains why the patch for the audio codecs has been reduced.